### PR TITLE
ci: only run build on source and TOML changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,13 @@ on:
   push:
     branches:
       - '**'
+    paths:
+      - '**/*.rs'
+      - '**/*.toml'
   pull_request:
+    paths:
+      - '**/*.rs'
+      - '**/*.toml'
 
 jobs:
   install-cross:


### PR DESCRIPTION
There's really no need to run it on README/docs changes.